### PR TITLE
修复 rc.7 下模型设置不可用

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Keep the connection trust bootstrap installed when Harness switches its
+  module loader from the queued registration sink to the live sink, restoring
+  remote model settings on `@deepseek-ai/dsh@0.1.0-rc.7` (#13).
+
 ## 0.3.5 (2026-08-20)
 
 ### Added

--- a/src/page-bootstrap.ts
+++ b/src/page-bootstrap.ts
@@ -13,6 +13,8 @@
  * It must not assign `ctx.provide` or other Cordis mixin accessors:
  * Context is a Proxy and those writes replace the shared ReflectService
  * method table (GitHub issue #9).
+ * The loader changes its registration sink when it becomes live, so the
+ * `load` accessor must wrap both the initial function and later assignments.
  *
  * Kept as an ES5 string so tests can eval it and the HTML injector can
  * splice it verbatim. Do not put `</script>` in this source.
@@ -58,13 +60,17 @@ export const PAGE_BOOTSTRAP_SOURCE = '(function(){'
   + 'return mod}'
   + 'function wrapLoader(loader){'
   + 'if(!loader||typeof loader.load!=="function"||loader.__dshFullRemoteTrusted)return loader;'
-  + 'var origLoad=loader.load;'
-  + 'loader.load=function(h){'
+  + 'function wrapLoad(fn){return function(h){'
   + 'if(h&&h.id===CONN&&typeof h.factory==="function"){'
   + 'var inner=h.factory;'
   + 'h=Object.assign({},h,{factory:function(req){return wrapExports(inner(req))}})'
   + '}'
-  + 'return origLoad.call(this,h)};'
+  + 'return fn.call(this,h)}}'
+  + 'var currentLoad=wrapLoad(loader.load);'
+  + 'try{Object.defineProperty(loader,"load",{configurable:true,enumerable:true,'
+  + 'get:function(){return currentLoad},'
+  + 'set:function(v){currentLoad=wrapLoad(v)}})}'
+  + 'catch(e7){loader.load=currentLoad}'
   + 'try{Object.defineProperty(loader,"__dshFullRemoteTrusted",{value:true})}catch(e9){loader.__dshFullRemoteTrusted=true}'
   + 'return loader}'
   + 'var current;'

--- a/tests/page-bootstrap.test.ts
+++ b/tests/page-bootstrap.test.ts
@@ -133,6 +133,30 @@ describe('page bootstrap', () => {
     assert.equal(env.seen, innerFactory)
   })
 
+  it('keeps wrapping after the module system replaces the loader sink', () => {
+    const env = bootPage()
+    env.provided = []
+    const handle = { isLoopback: false, api: {} }
+    env.factoryModule = {
+      apply(ctx: { provide(name: string, value: unknown): void }) {
+        ctx.provide('connection', handle)
+      },
+    }
+    vm.runInContext(`
+      var captured;
+      globalThis.__ModuleLoader__ = { load: function() {} };
+      globalThis.__ModuleLoader__.load = function(h) { captured = h };
+      globalThis.__ModuleLoader__.load({
+        id: ${JSON.stringify(CONNECTION_CLIENT_ID)},
+        factory: function() { return globalThis.factoryModule }
+      });
+      globalThis.wrappedMod = captured.factory(function() {});
+    `, env)
+    mockCtx(env, handle)
+    vm.runInContext('globalThis.wrappedMod.apply(globalThis.ctx)', env)
+    assert.equal(handle.isLoopback, true)
+  })
+
   it('leaves isLoopback alone when the trust flag is cleared', () => {
     const env = bootPage()
     vm.runInContext('delete globalThis.__DSH_FULL_REMOTE_TRUSTED__', env)


### PR DESCRIPTION
修复 #13。

原因：新版 Harness 在模块系统从 queue 切换到 live 时会重新赋值 __ModuleLoader__.load，原有的一次性包装因此被覆盖，connection 插件不会再被注入 isLoopback 信任，远程模型页退回 memory settings。

本 PR 仅将 load 包装改为 accessor：初始函数和后续赋值都会经过同一包装逻辑，不改 Cordis Context，也不改代理或鉴权行为。

验证：
- 新增 queue → live sink 替换的回归测试（修复前失败、修复后通过）
- pnpm run check:ci 通过（206 passed，2 skipped）
